### PR TITLE
Add dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM golang:1.9 as build
+MAINTAINER Menzo Wijmenga
+# Install dep for dependency management
+RUN go get github.com/golang/dep/cmd/dep
+
+# Install & Cache dependencies
+COPY Gopkg.lock Gopkg.toml /go/src/slurp/
+WORKDIR /go/src/slurp
+RUN dep ensure -vendor-only
+
+# Add app
+COPY . /go/src/slurp
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o slurp .
+
+# Download ca-certificates
+FROM alpine:latest as certs
+RUN apk --update add ca-certificates
+
+# Put everything together in a clean image.
+FROM alpine
+WORKDIR /slurp
+
+# Copy slurp binary into PATH
+COPY --from=build /go/src/slurp/slurp /bin/slurp
+
+# Add certs.
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Add permutations to workdir.
+COPY *.json ./
+
+# Run slurp when the container starts
+ENTRYPOINT [ "/bin/slurp" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ COPY --from=build /go/src/slurp/slurp /bin/slurp
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 # Add permutations to workdir.
-COPY *.json ./
+ARG permutations=permutations.json
+COPY ${permutations} ./permutations.json
 
 # Run slurp when the container starts
 ENTRYPOINT [ "/bin/slurp" ]

--- a/large.Dockerfile
+++ b/large.Dockerfile
@@ -1,2 +1,0 @@
-FROM slurp
-RUN mv permutations-large.json permutations.json

--- a/large.Dockerfile
+++ b/large.Dockerfile
@@ -1,0 +1,2 @@
+FROM slurp
+RUN mv permutations-large.json permutations.json


### PR DESCRIPTION
Added a Dockerfile so users can build slurp without having go installed on their system. The final image size is just 13.5 MB.

I pushed the final result to hub.docker.com here:
https://hub.docker.com/r/menzo/slurp/

You can build it yourself using the following steps:
```
$ git clone https://github.com/menzow/slurp slurp-menzow
$ cd slurp-menzow
$ docker build -t slurp .
$ docker build -t slurp:large -f large.Dockerfile .
```

You will now have two images. One for regular scans, and one tagged ':large` for scans using the large permutation set. To use them run one of the following commands:

```
$ docker run --rm -ti slurp domain -t example.com
$ docker run --rm -ti slurp:large domain -t example.com
```

To run slurp using docker without building the image yourself, you can run:
```
$ docker run --rm -ti menzo/slurp domain -t example.com
$ docker run --rm -ti menzo/slurp:large domain -t example.com
```